### PR TITLE
add antialiasing to whitty dialoguebox & initial ballistic cutscene background

### DIFF
--- a/source/DialogueBox.hx
+++ b/source/DialogueBox.hx
@@ -112,6 +112,7 @@ class DialogueBox extends FlxSpriteGroup
 				box.frames = Paths.getSparrowAtlas('speech_bubble_talking', 'shared');
 				box.animation.addByPrefix('normalOpen', 'Speech Bubble Normal Open', 24, false);
 				box.animation.addByIndices('normal', 'speech bubble normal', [11], "", 24);
+				box.antialiasing = true;
 		}
 
 		box.animation.play('normalOpen');
@@ -172,6 +173,7 @@ class DialogueBox extends FlxSpriteGroup
 							portraitLeft.animation.addByPrefix('enter', 'Whitty Portrait Crazy', 24, true);
 					}
 
+					portraitLeft.antialiasing = true;
 					portraitLeft.updateHitbox();
 					portraitLeft.scrollFactor.set();
 					add(portraitLeft);
@@ -180,6 +182,7 @@ class DialogueBox extends FlxSpriteGroup
 					portraitRight = new FlxSprite(800, FlxG.height - 489);
 					portraitRight.frames = Paths.getSparrowAtlas('boyfriendPort', 'bonusWeek');
 					portraitRight.animation.addByPrefix('enter', 'BF portrait enter', 24, false);
+					portraitRight.antialiasing = true;
 					portraitRight.updateHitbox();
 					portraitRight.scrollFactor.set();
 					add(portraitRight);
@@ -211,7 +214,10 @@ class DialogueBox extends FlxSpriteGroup
 		if (gaming)
 			dropText.color = 0xFFD89494;
 		else
+		{
 			dropText.color = FlxColor.RED;
+			dropText.antialiasing = true;
+		}
 		add(dropText);
 
 		swagDialogue = new FlxTypeText(240, 500, Std.int(FlxG.width * 0.6), "", 32);
@@ -219,7 +225,10 @@ class DialogueBox extends FlxSpriteGroup
 		if (gaming)
 			swagDialogue.color = 0xFF3F2021;
 		else
+		{
 			swagDialogue.color = FlxColor.BLACK;
+			swagDialogue.antialiasing = true;
+		}
 
 		if (PlayState.SONG.song.toLowerCase() != 'lo-fight' && PlayState.SONG.song.toLowerCase() != 'b-lo-fight' && PlayState.SONG.song.toLowerCase() != 'overhead' && PlayState.SONG.song.toLowerCase() != 'b-overhead')
 			swagDialogue.sounds = [FlxG.sound.load(Paths.sound('pixelText'), 0.6)];

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -679,8 +679,6 @@ class PlayState extends MusicBeatState
             if (SONG.stage == 'ballisticAlley')
             {
               trace('pogging');
-			  wBg.x = -600;
-			  wBg.y = -200;
 			  wBg.antialiasing = true;
 			  var bgTex = Paths.getSparrowAtlas('BallisticBackground', 'bonusWeek');
               nwBg = new FlxSprite(-600, -200);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -679,7 +679,10 @@ class PlayState extends MusicBeatState
             if (SONG.stage == 'ballisticAlley')
             {
               trace('pogging');
-              var bgTex = Paths.getSparrowAtlas('BallisticBackground', 'bonusWeek');
+			  wBg.x = -600;
+			  wBg.y = -200;
+			  wBg.antialiasing = true;
+			  var bgTex = Paths.getSparrowAtlas('BallisticBackground', 'bonusWeek');
               nwBg = new FlxSprite(-600, -200);
               nwBg.frames = bgTex;
               nwBg.antialiasing = true;


### PR DESCRIPTION
makes them look all smooth and not jaggitiyitiy

<details>
  <summary>before</summary>
  
![2021-05-25_14-22-40_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570422-f2093100-bd64-11eb-9fe3-a19751684eba.png)
![2021-05-25_14-23-00_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570427-f3d2f480-bd64-11eb-8ef5-8721d50782c3.png)
![2021-05-25_14-23-29_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570431-f59cb800-bd64-11eb-8814-217ac05e3bb2.png)
![2021-05-25_14-23-36_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570433-f6354e80-bd64-11eb-971b-659c5974270b.png)

</details>

<details>
  <summary>after</summary>
  
![2021-05-25_14-19-52_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570455-ff262000-bd64-11eb-802a-66d93570828c.png)
![2021-05-25_14-19-10_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570462-00efe380-bd65-11eb-8ff6-44a12a97ad12.png)
![2021-05-25_14-20-27_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570469-02211080-bd65-11eb-83c3-a3d160f3f469.png)
![2021-05-25_14-20-34_Kade_Engine](https://user-images.githubusercontent.com/15317421/119570472-03523d80-bd65-11eb-9c55-4c37014d8d05.png)

</details>